### PR TITLE
Perform root digest

### DIFF
--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -10,15 +10,12 @@
             }, 10);
         }
 
-        function createDebouncing(theThis, func, delay) {
+        function createDebouncingVersion(func, delay) {
             var debounceTimeout;
-            var debounced = function () {
+            return function () {
                 clearTimeout(debounceTimeout);
-                debounceTimeout = setTimeout(function () {
-                    func.call(theThis);
-                }, delay);
+                debounceTimeout = setTimeout(func, delay);
             };
-            return debounced;
         }
 
         var link = function(scope, element, attr) {
@@ -78,7 +75,7 @@
                     scope.$digest();
 
                     if (!$rootScope.debouncingApplyAsync) {
-                        $rootScope.debouncingApplyAsync = createDebouncing($rootScope, function () {
+                        $rootScope.debouncingApplyAsync = createDebouncingVersion(function () {
                             $rootScope.$applyAsync();
                         }, 10);
                     }

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -27,10 +27,10 @@
             }
 
             if (attr.hashkey !== element.attr('hashkey')) {
-                var unwatch = scope.$watch(function() {
+                var unwatchFunction = scope.$watch(function() {
                     return element.attr('hashkey');
                 }, function() {
-                    unwatch && unwatch();
+                    unwatchFunction && unwatchFunction();
                     link.call(this, scope, element, attr);
                 });
                 return true;

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -1,7 +1,7 @@
 "use strict";
 
 (function() {
-    function viewportWatch(scrollMonitor, $timeout, $parse) {
+    function viewportWatch(scrollMonitor, $timeout, $parse, $rootScope) {
         var viewportUpdateTimeout;
         function debouncedViewportUpdate() {
             $timeout.cancel(viewportUpdateTimeout);
@@ -97,6 +97,6 @@
             link: link
         };
     }
-    viewportWatch.$inject = [ "scrollMonitor", "$timeout", "$parse" ];
+    viewportWatch.$inject = [ "scrollMonitor", "$timeout", "$parse", "$rootScope" ];
     angular.module("angularViewportWatch", []).directive("viewportWatch", viewportWatch).value("scrollMonitor", window.scrollMonitor);
 })();

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -10,6 +10,17 @@
             }, 10);
         }
 
+        function createDebouncing(theThis, func, delay) {
+            var debounceTimeout;
+            var debounced = function () {
+                clearTimeout(debounceTimeout);
+                debounceTimeout = setTimeout(function () {
+                    func.call(theThis);
+                }, delay);
+            };
+            return debounced;
+        }
+
         var link = function(scope, element, attr) {
             if($parse(attr.viewportWatch)(scope) == false){
                 return false;
@@ -65,6 +76,13 @@
                 } while (next);
                 if (digest) {
                     scope.$digest();
+
+                    if (!$rootScope.debouncingApplyAsync) {
+                        $rootScope.debouncingApplyAsync = createDebouncing($rootScope, function () {
+                            $rootScope.$applyAsync();
+                        }, 10);
+                    }
+                    $rootScope.debouncingApplyAsync();
                 }
             }
             function disableDigest() {


### PR DESCRIPTION
Perform a debouncing root digest when watchers are enabled.
- Added `createDebouncingVersion()` to create a debouncing version of `scope.$applyAsync()`

Small tweaks:
- Renamed a local variable
- Some code indentation was changed.
